### PR TITLE
Simpler custom queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ module Functions
     argument :country_code, types.String
 
     def call(obj, args, ctx)
-      query = super(obj, args, ctx)
-      query.where(country_code: args[:countryCode]) if args[:countryCode]
-      query
+      query(obj, args, ctx) do |relation|
+        relation.where(country_code: args[:countryCode]) if args[:countryCode]
+      end
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ end
 
 Above changes will in addition to the base query capabilities from `graphql-functions` allow the query to filter by `countryCode` in the `people` field like:
 
-```
+```graphql
 {
   people(countryCode: 'us', limit: 2, offset: 5) {
     id,
@@ -135,13 +135,13 @@ Above changes will in addition to the base query capabilities from `graphql-func
 
 ### Element
 Element function is intended to be used with a query with a single field output like `person` in the example: The only available argument is id:
-- `id: Int`. Filter by the specified id.
+- `id: Int` Filter by the specified id.
 
 ### Array
 Array function add filters-like arguments to the query:
-- `offset: Int`). Skip the specified argument of records.
-- `limit: Int`). Do not return more rows than the argument.
-- `ìds: [Int]`). Filter by the specified ids.
+- `offset: Int` Skip the specified argument of records.
+- `limit: Int` Do not return more rows than the argument.
+- `ids: [Int]` Filter by the specified ids.
 
 
 ## Development

--- a/lib/graphql/functions/array.rb
+++ b/lib/graphql/functions/array.rb
@@ -14,6 +14,12 @@ module GraphQL
         query
       end
 
+      def query(*args)
+        relation = call(*args)
+        filtered_relation = yield(relation) if block_given?
+        filtered_relation || relation
+      end
+
       def type
         @type ||= self.class.types[!type_class]
       end

--- a/lib/graphql/functions/version.rb
+++ b/lib/graphql/functions/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Functions
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end


### PR DESCRIPTION
Custom relation filter may now be easier with the `query` method. Before you have to do something like: 

```ruby
def call(obj, args, ctx)
  query = super(obj, args, ctx)
  query.where(country_code: args[:countryCode]) if args[:countryCode]
  query
end
```

Using `query`:

```ruby
def call(obj, args, ctx)
  query(obj, args, ctx) do |relation| 
    relation.where(country_code: args[:countryCode]) if args[:countryCode]
  end
end
```