### PR TITLE
Allow elements functions to implement query on subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ module Types
   QueryType = GraphQL::ObjectType.define do
     name "Query"
 
-    field :person, function: Functions::Person
-    field :people, function: Functions::People
+    field :person, function: Functions::Person.create
+    field :people, function: Functions::People.create
   end
 end
 ```
@@ -136,6 +136,8 @@ Above changes will in addition to the base query capabilities from `graphql-func
 ### Element
 Element function is intended to be used with a query with a single field output like `person` in the example: The only available argument is id:
 - `id: Int` Filter by the specified id.
+
+If `id` is not specified or if the subclass implements its own `query` method which does not return a single element, the first element of the model is returned.
 
 ### Array
 Array function add filters-like arguments to the query:

--- a/lib/graphql/functions/element.rb
+++ b/lib/graphql/functions/element.rb
@@ -5,8 +5,12 @@ module GraphQL
     class Element < Base
       argument :id, !types.ID
 
-      def call(_, args, _)
-        @model_class.find(args[:id])
+      def call(*attrs)
+        _, args, = attrs
+        return @model_class.find(args[:id]) if args[:id]
+        return @model_class.first unless respond_to?(:query)
+        relation = query(@model_class, *attrs)
+        relation.is_a?(ActiveRecord::Relation) ? relation.first : relation
       end
 
       def type

--- a/lib/graphql/functions/version.rb
+++ b/lib/graphql/functions/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Functions
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end

--- a/spec/graphql/functions/array_spec.rb
+++ b/spec/graphql/functions/array_spec.rb
@@ -72,26 +72,20 @@ RSpec.describe GraphQL::Functions::Array do
         Function.create.call(nil, { order_by: 'id', desc: true }, nil)
       ).to eq(elements)
     end
-  end
 
-  context '#query method on the subclass' do
-    before(:example) do
-      stub_const(
-        'Function',
-        Class.new(GraphQL::Functions::Array) do
-          model Mock
+    context 'when #query method is implemented on the subclass' do
+      it 'filters the returned relation' do
+        Function.class_eval do
           def query(relation, *_)
             relation.order(id: :desc)
           end
         end
-      )
-    end
 
-    it 'filters the returned relation' do
-      elements = create(5) { |m| m.order(id: :desc) }
-      expect(
-        Function.create.call(nil, default_args, nil)
-      ).to eq(elements)
+        elements = create(5) { |m| m.order(id: :desc) }
+        expect(
+          Function.create.call(nil, default_args, nil)
+        ).to eq(elements)
+      end
     end
   end
 

--- a/spec/graphql/functions/element_spec.rb
+++ b/spec/graphql/functions/element_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe GraphQL::Functions::Element do
   end
 
   describe '#call' do
-    context 'when id arg is passed' do
+    context 'when id arg is present' do
       it 'return the proper element' do
         mock = Mock.create
         expect(Function.create.call(nil, { id: mock.id }, nil)).to eq(mock)
       end
     end
 
-    context 'when id arg is not passed' do
+    context 'when id arg is not present' do
       context 'and #query method is not implemented in subclass' do
         it 'returns the first element' do
           Mock.create

--- a/spec/graphql/functions/element_spec.rb
+++ b/spec/graphql/functions/element_spec.rb
@@ -13,10 +13,56 @@ RSpec.describe GraphQL::Functions::Element do
 
   after(:context) { ActiveRecordMock.teardown }
 
+  let(:default_args) do
+    GraphQL::Query::Arguments.new({}, argument_definitions: {})
+  end
+
   describe '#call' do
-    it 'return the proper element' do
-      mock = Mock.create
-      expect(Function.create.call(nil, { id: mock.id }, nil)).to eq(mock)
+    context 'when id arg is passed' do
+      it 'return the proper element' do
+        mock = Mock.create
+        expect(Function.create.call(nil, { id: mock.id }, nil)).to eq(mock)
+      end
+    end
+
+    context 'when id arg is not passed' do
+      context 'and #query method is not implemented in subclass' do
+        it 'returns the first element' do
+          Mock.create
+          expect(Function.create.call(nil, {}, nil)).to eq(Mock.first)
+        end
+      end
+
+      context 'when #query method is implemented in subclass' do
+        context 'and #query returns an array' do
+          it 'defaults to the first element' do
+            5.times { Mock.create }
+            Function.class_eval do
+              def query(*_)
+                Mock.all
+              end
+            end
+            expect(Function.create.call(nil, default_args, nil))
+              .to eq(Mock.first)
+          end
+        end
+
+        context 'and #query returns a single element' do
+          it 'returns the proper element' do
+            5.times { Mock.create }
+            Function.class_eval do
+              def query(relation, *attrs)
+                _, args, = attrs
+                relation.where(id: args[:index])
+              end
+            end
+
+            second = Mock.second
+            expect(Function.create.call(nil, { index: second.id }, nil))
+              .to eq(second)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Now subclasses of `element` function may implement a query to fetch the result. 

**Rules**:
- if `id` arg is specified, then a model with that id is fetched and returned
- if `id` arg is not specified then the query method on subclass is invoked. If the query method does not return a single element, then the first one is returned.
- if both `id` argument and `query` are not specified, then the first element of the model is returned